### PR TITLE
Feature/edit book

### DIFF
--- a/src/hooks/useBooks/useBooks.test.ts
+++ b/src/hooks/useBooks/useBooks.test.ts
@@ -3,6 +3,7 @@ import {
   addedBookMock,
   booksMocks,
   createdBookMock,
+  errorEditMock,
 } from "../../mocks/booksMock";
 import useBooks from "./useBooks";
 import { server } from "../../mocks/server";
@@ -46,7 +47,7 @@ describe("Given a useBooks function", () => {
       server.resetHandlers(...handlers);
 
       const bookId = booksMocks[0].id;
-      const message = modalData.message.okDeleted;
+      const expectedMessage = modalData.message.okDeleted;
 
       const {
         result: {
@@ -56,9 +57,9 @@ describe("Given a useBooks function", () => {
 
       await deleteBooks(bookId);
 
-      const expectedMessage = store.getState().ui.modalState.message;
+      const message = store.getState().ui.modalState.message;
 
-      expect(message).toBe(expectedMessage);
+      expect(expectedMessage).toBe(message);
     });
 
     describe("When it calls the deleteBooks function with a incorrect id", () => {
@@ -66,7 +67,7 @@ describe("Given a useBooks function", () => {
         server.resetHandlers(...errorHandlers);
 
         const errorId = "sdkfnsdfl";
-        const message = modalData.message.errorRemove;
+        const expectedMessage = modalData.message.errorRemove;
 
         const {
           result: {
@@ -76,9 +77,9 @@ describe("Given a useBooks function", () => {
 
         await deleteBooks(errorId);
 
-        const expectedMessage = store.getState().ui.modalState.message;
+        const message = store.getState().ui.modalState.message;
 
-        expect(message).toBe(expectedMessage);
+        expect(expectedMessage).toBe(message);
       });
     });
   });
@@ -106,7 +107,7 @@ describe("Given a useBooks function", () => {
       server.resetHandlers(...errorHandlers);
 
       createdBookMock.author = "";
-      const message = modalData.message.erorAdd;
+      const expectedMessage = modalData.message.erorAdd;
 
       const {
         result: {
@@ -116,9 +117,9 @@ describe("Given a useBooks function", () => {
 
       await createBook(createdBookMock);
 
-      const expectedMessage = store.getState().ui.modalState.message;
+      const message = store.getState().ui.modalState.message;
 
-      expect(message).toBe(expectedMessage);
+      expect(expectedMessage).toBe(message);
     });
   });
 
@@ -144,7 +145,7 @@ describe("Given a useBooks function", () => {
     test("Then it should show the feedback message 'Can't show this book now'", async () => {
       server.resetHandlers(...errorHandlers);
       const idBook = "647fa740ee528da72718451f";
-      const message = modalData.message.errorMyBook;
+      const expectedMessage = modalData.message.errorMyBook;
 
       const {
         result: {
@@ -154,7 +155,47 @@ describe("Given a useBooks function", () => {
 
       await getMyBook(idBook);
 
-      const expectedMessage = store.getState().ui.modalState.message;
+      const message = store.getState().ui.modalState.message;
+
+      expect(expectedMessage).toBe(message);
+    });
+  });
+
+  describe("When it calls the editBook function with a valid book data to update", () => {
+    test("Then it should show a modal with the message 'You book has been successfully modified'", async () => {
+      server.resetHandlers(...handlers);
+      const bookData = addedBookMock;
+      const expectedMessage = modalData.message.okEdit;
+
+      const {
+        result: {
+          current: { editBook },
+        },
+      } = renderHook(() => useBooks(), { wrapper: wrapper });
+
+      await editBook(bookData);
+
+      const message = store.getState().ui.modalState.message;
+
+      expect(message).toBe(expectedMessage);
+    });
+  });
+
+  describe("When it calls the editBook function with an invalid book data to update", () => {
+    test("Then it should show the message 'Couldn't edit this book'", async () => {
+      server.resetHandlers(...errorHandlers);
+      const expectedMessage = modalData.message.errorEdit;
+      const errorDataBook = errorEditMock;
+
+      const {
+        result: {
+          current: { editBook },
+        },
+      } = renderHook(() => useBooks(), { wrapper: wrapper });
+
+      await editBook(errorDataBook);
+
+      const message = store.getState().ui.modalState.message;
 
       expect(message).toBe(expectedMessage);
     });

--- a/src/hooks/useBooks/useBooks.ts
+++ b/src/hooks/useBooks/useBooks.ts
@@ -122,7 +122,7 @@ const useBooks = () => {
       const {
         data: { editedBook },
       } = await axios.put<{ editedBook: BookDataStructure }>(
-        `${apiUrl}/books}`,
+        `${apiUrl}/books`,
         bookData
       );
       dispatch(hideLoadingActionCreator());

--- a/src/hooks/useBooks/useBooks.ts
+++ b/src/hooks/useBooks/useBooks.ts
@@ -114,7 +114,39 @@ const useBooks = () => {
     [dispatch]
   );
 
-  return { getBooks, deleteBooks, createBook, getMyBook };
+  const editBook = async (
+    bookData: BookDataStructure
+  ): Promise<BookStructure | undefined> => {
+    try {
+      dispatch(showLoadingActionCreator());
+      const {
+        data: { editedBook },
+      } = await axios.put<{ editedBook: BookDataStructure }>(
+        `${apiUrl}/books}`,
+        bookData
+      );
+      dispatch(hideLoadingActionCreator());
+      dispatch(
+        showModalActionCreator({
+          isError: false,
+          message: modalData.message.okEdit,
+          isVisible: true,
+        })
+      );
+      return editedBook;
+    } catch {
+      dispatch(hideLoadingActionCreator());
+      dispatch(
+        showModalActionCreator({
+          isError: true,
+          message: modalData.message.errorEdit,
+          isVisible: true,
+        })
+      );
+    }
+  };
+
+  return { getBooks, deleteBooks, createBook, getMyBook, editBook };
 };
 
 export default useBooks;

--- a/src/mocks/booksMock.ts
+++ b/src/mocks/booksMock.ts
@@ -85,3 +85,17 @@ export const createdBookMock: BookStructure = {
   cosmos:
     "Un escritor argentino se embarca en un viaje a Montevideo que lo llevará a cuestionarse su vida, su matrimonio y sus ambiciones literarias.",
 };
+
+export const errorEditMock: BookDataStructure = {
+  id: "errorId",
+  title: "La uruguaya",
+  author: "Pedro Mairal",
+  frontPage: "image_la_uruguaya.jpg",
+  publicationYear: "2016",
+  editorial: "Libros del Asteroide",
+  status: false,
+  rating: 4,
+  destination: "keep",
+  cosmos:
+    "Un escritor argentino se embarca en un viaje a Montevideo que lo llevará a cuestionarse su vida, su matrimonio y sus ambiciones literarias.",
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -22,6 +22,13 @@ export const handlers = [
   rest.get(`${apiUrl}/books/:id`, (_req, res, ctx) => {
     return res(ctx.status(200), ctx.json({ myBook: addedBookMock }));
   }),
+
+  rest.put(`${apiUrl}/books`, (_req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({ message: modalData.message.okEdit })
+    );
+  }),
 ];
 
 export const errorHandlers = [
@@ -47,6 +54,13 @@ export const errorHandlers = [
     return res(
       ctx.status(404),
       ctx.json({ message: modalData.message.errorMyBook })
+    );
+  }),
+
+  rest.put(`${apiUrl}/books`, (_req, res, ctx) => {
+    return res(
+      ctx.status(400),
+      ctx.json({ message: modalData.message.errorEdit })
     );
   }),
 ];


### PR DESCRIPTION
Creada la función editBook y aádida a useBooks.
- Añadida la gestión de feedback al usuario que corresponde a esta función (enseñar el spinner mientras se realiza la petición + enseñar modal de error con el mensaje correspondiente a este caso)

Testeados casos de uso que corresponden a la función editBook
- Que cuando se edita un libro se ensaña un modal con mensaje positivo
- Que cuando no se puede editar un libro se enseña un modal con feedback negativo

Creados los handlers necesarios para poder testear los casos de uso antes mencionados

